### PR TITLE
Do not wait on new tests if adt_ignore_failure_for_new_tests is set

### DIFF
--- a/britney2/policies/autopkgtest.py
+++ b/britney2/policies/autopkgtest.py
@@ -1194,7 +1194,9 @@ class AutopkgtestPolicy(BasePolicy):
         except KeyError:
             # no result for src/arch; still running?
             if arch in self.pending_tests.get(trigger, {}).get(src, []):
-                if baseline_result != Result.FAIL and not self.has_force_badtest(src, ver, arch):
+                if baseline_result == Result.NONE and self.options.adt_ignore_failure_for_new_tests:
+                    result = 'RUNNING-ALWAYSFAIL'
+                elif baseline_result != Result.FAIL and not self.has_force_badtest(src, ver, arch):
                     result = 'RUNNING'
                 else:
                     result = 'RUNNING-ALWAYSFAIL'


### PR DESCRIPTION
This is not the most concise way of writing the new condition with boolean logic, but IMO it's far more readable than the alternative.